### PR TITLE
DATA-1172 - ensuring that we filter events in parallel so that the pubsub subscription doesn't get backed up

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,5 +161,7 @@ function transform(inJson) {
 
 Dataflow templates may be found in `infusionsoft.dataflow.templates`
 
+Dataflow template metadatas may be found in `resources/infusionsoft/json`
+
 JavaScript transformers may be found in `resources/infusionsoft/js`
 

--- a/src/main/java/com/infusionsoft/dataflow/templates/FilterPubsubTriggers.java
+++ b/src/main/java/com/infusionsoft/dataflow/templates/FilterPubsubTriggers.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.options.StreamingOptions;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Reshuffle;
 import org.apache.beam.sdk.util.RetryHttpRequestInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -219,6 +220,7 @@ public class FilterPubsubTriggers {
     pipeline
         .apply("Read Events", PubsubIO.readStrings()
             .fromTopic(options.getPubsubReadTopic()))
+        .apply("Shard Events", Reshuffle.viaRandomKey())  // this ensures that we filter the events in parallel
         .apply("Filter Events", ParDo.of(new ExtractAndFilterEventsFn()))
         .apply("Write Events", PubsubIO.writeStrings()
             .to(options.getPubsubWriteTopic()));

--- a/src/main/resources/infusionsoft/json/filter_metadata.json
+++ b/src/main/resources/infusionsoft/json/filter_metadata.json
@@ -1,0 +1,18 @@
+{
+  "name": "Filter PubSub Triggers",
+  "description": "A pipeline that reads pubsub events, checks if there are any triggers listening for them, and then writes to another topic if so",
+  "parameters": [
+    {
+      "name": "pubsubReadTopic",
+      "label": "Pubsub topic to read data from",
+      "help_text": "projects/<project-id>/topics/<topic-name>",
+      "is_optional": false
+    },
+    {
+      "name": "pubsubWriteTopic",
+      "label": "Pubsub topic to write data to",
+      "help_text": "projects/<project-id>/topics/<topic-name>",
+      "is_optional": false
+    }
+  ]
+}

--- a/src/main/resources/infusionsoft/json/ps2ps_metadata.json
+++ b/src/main/resources/infusionsoft/json/ps2ps_metadata.json
@@ -1,0 +1,30 @@
+{
+  "name": "Custom PubSub to PubSub",
+  "description": "A pipeline that reads pubsub events, transforms them, and then writes to another topic",
+  "parameters": [
+    {
+      "name": "pubsubReadTopic",
+      "label": "Pubsub topic to read data from",
+      "help_text": "projects/<project-id>/topics/<topic-name>",
+      "is_optional": false
+    },
+    {
+      "name": "javascriptTextTransformGcsPath",
+      "label": "GCS location of your Javascript UDF",
+      "help_text": "gs://my_bucket/my_function.js",
+      "is_optional": false
+    },
+    {
+      "name": "javascriptTextTransformFunctionName",
+      "label": "The name of the Javascript function you wish to call as your UDF",
+      "help_text": "transform",
+      "is_optional": false
+    },
+    {
+      "name": "pubsubWriteTopic",
+      "label": "Pubsub topic to write data to",
+      "help_text": "projects/<project-id>/topics/<topic-name>",
+      "is_optional": false
+    }
+  ]
+}


### PR DESCRIPTION
DATA-1172 - ensuring that we filter events in parallel so that the pubsub subscription doesn't get backed up