### PR TITLE
PDS-2803 Minor bumps to v2s that we don't currently use

### DIFF
--- a/v2/cdc-parent/cdc-embedded-connector/pom.xml
+++ b/v2/cdc-parent/cdc-embedded-connector/pom.xml
@@ -141,7 +141,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.3</version>
+      <version>1.9.4</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/v2/streaming-data-generator/pom.xml
+++ b/v2/streaming-data-generator/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <json-data-generator.version>1.10</json-data-generator.version>
-    <snakeyaml.version>1.23</snakeyaml.version>
+    <snakeyaml.version>1.26</snakeyaml.version>
     <truth.version>1.0.1</truth.version>
    </properties>
 


### PR DESCRIPTION
These are minor version bumps to v2 template dependencies that we don't currently use, so this is a no-deployment-necessary change.