### PR TITLE
PDS-4784: Fix vulnerability for org.apache.derby

### DIFF
--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -49,7 +49,7 @@
     <commons-text.version>1.10.0</commons-text.version>
     <google-cloud-bigquery.version>1.108.0</google-cloud-bigquery.version>
     <grpc.gen.version>1.13.1</grpc.gen.version>
-    <derby.version>10.14.2.0</derby.version>
+    <derby.version>10.17.1.0</derby.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
     <threetenbp.version>1.4.4</threetenbp.version>
     <spring.version>5.2.22.RELEASE</spring.version>

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -49,7 +49,7 @@
     <commons-text.version>1.10.0</commons-text.version>
     <google-cloud-bigquery.version>1.108.0</google-cloud-bigquery.version>
     <grpc.gen.version>1.13.1</grpc.gen.version>
-    <derby.version>10.17.1.0</derby.version>
+    <derby.version>10.15.1.3</derby.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
     <threetenbp.version>1.4.4</threetenbp.version>
     <spring.version>5.2.22.RELEASE</spring.version>

--- a/v2/googlecloud-to-googlecloud/pom.xml
+++ b/v2/googlecloud-to-googlecloud/pom.xml
@@ -29,7 +29,7 @@
   <artifactId>googlecloud-to-googlecloud</artifactId>
 
   <properties>
-    <derby.version>10.14.2.0</derby.version>
+    <derby.version>10.17.1.0</derby.version>
     <avro.version>1.8.2</avro.version>
     <dlp.version>2.1.0</dlp.version>
   </properties>

--- a/v2/googlecloud-to-googlecloud/pom.xml
+++ b/v2/googlecloud-to-googlecloud/pom.xml
@@ -29,7 +29,7 @@
   <artifactId>googlecloud-to-googlecloud</artifactId>
 
   <properties>
-    <derby.version>10.17.1.0</derby.version>
+    <derby.version>10.15.1.3</derby.version>
     <avro.version>1.8.2</avro.version>
     <dlp.version>2.1.0</dlp.version>
   </properties>


### PR DESCRIPTION
https://keap.atlassian.net/browse/PDS-4784
With [10.15.1.3](https://lists.apache.org/thread/vjl42y0p86c7lh7lsm3bfth6dx83nhb8) addressing [CVE-2022-46337](https://nvd.nist.gov/vuln/detail/CVE-2022-46337)

| Package	| Type	| Update	| Change |
| ------------- | ------------- | ------------- | ------------- | 
| [org.apache.derby:derby](http://db.apache.org/derby/) ([source](http://svn.apache.org/viewcvs.cgi/db/derby/code/trunk/?root=Apache-SVN))	|  compile |	minor | 	`10.14.2.0` -> `10.15.1.3` |

| Severity	| [<img alt="" width="19" height="20" src="https://camo.githubusercontent.com/250c28ef3baeff15b76d1d51906c2b46aa02c4ff38707e7cac540e32e7c61b76/68747470733a2f2f7768697465736f757263652d7265736f75726365732e7768697465736f75726365736f6674776172652e636f6d2f63767373332e706e67">](#) CVSS Score	| CVE | 
| ------------- | ------------- | ------------- | 
| ![Medium](https://camo.githubusercontent.com/9ca917de7cff1e0de56250f5c03b3aa18a6681345de980d9c86c74dd1163a6d9/68747470733a2f2f7768697465736f757263652d7265736f75726365732e7768697465736f75726365736f6674776172652e636f6d2f6d656469756d5f76756c5f62622e706e673f) Medium | 	5.5	| [CVE-2022-46337](https://nvd.nist.gov/vuln/detail/CVE-2022-46337)

#### Mitigation
Users should upgrade to Java 21 and Derby `10.17.1.0`. Alternatively, users who wish to remain on older Java versions should build their own Derby distribution from one of the release families to which the fix was backported: `10.16`, `**_10.15_**`, and `10.14`. Those are the releases which correspond, respectively, with Java LTS versions 17, **_11_**, and 8.