### PR TITLE
PAPI-2050 Prod dataflow job failed, revert derby change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <commons-io.version>2.11.0</commons-io.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <conscrypt.version>2.5.2</conscrypt.version>
-    <derby.version>10.14.3.0</derby.version>
+    <derby.version>10.14.2.0</derby.version>
     <grpc.gen.version>1.13.1</grpc.gen.version>
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.3.6</hadoop.version>

--- a/v2/flagship-events/src/main/java/com/keap/dataflow/flagshipevents/FlagshipEventsPubsubToBigQuery.java
+++ b/v2/flagship-events/src/main/java/com/keap/dataflow/flagshipevents/FlagshipEventsPubsubToBigQuery.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-
 import org.apache.beam.repackaged.core.org.apache.commons.lang3.StringUtils;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.Coder;
@@ -104,7 +103,7 @@ public class FlagshipEventsPubsubToBigQuery {
                     new Partition.PartitionFn<TableRow>() {
                       public int partitionFor(TableRow tableRow, int numPartitions) {
                         TableName tableFromRow = getTableFromRow(tableRow);
-                        if(tableFromRow == TableName.UNDEFINED) {
+                        if (tableFromRow == TableName.UNDEFINED) {
                           LOG.error(String.format("Table UNDEFINED: %s", tableRow.get("event")));
                         }
                         return tableFromRow.index;
@@ -216,8 +215,10 @@ public class FlagshipEventsPubsubToBigQuery {
 
     public static TableName getByTable(String table) {
       return Arrays.stream(TableName.values())
-          .filter(it -> it.getFormattedTable().equals(StringUtils.defaultString(table).toLowerCase()))
-          .findFirst().orElse(UNDEFINED);
+          .filter(
+              it -> it.getFormattedTable().equals(StringUtils.defaultString(table).toLowerCase()))
+          .findFirst()
+          .orElse(UNDEFINED);
     }
   }
 

--- a/v2/flagship-events/src/main/java/com/keap/dataflow/flagshipevents/FlagshipEventsPubsubToBigQuery.java
+++ b/v2/flagship-events/src/main/java/com/keap/dataflow/flagshipevents/FlagshipEventsPubsubToBigQuery.java
@@ -24,6 +24,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.apache.beam.repackaged.core.org.apache.commons.lang3.StringUtils;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
@@ -101,7 +103,11 @@ public class FlagshipEventsPubsubToBigQuery {
                     TableName.values().length,
                     new Partition.PartitionFn<TableRow>() {
                       public int partitionFor(TableRow tableRow, int numPartitions) {
-                        return getTableFromRow(tableRow).index;
+                        TableName tableFromRow = getTableFromRow(tableRow);
+                        if(tableFromRow == TableName.UNDEFINED) {
+                          LOG.error(String.format("Table UNDEFINED: %s", tableRow.get("event")));
+                        }
+                        return tableFromRow.index;
                       }
                     }));
 
@@ -189,7 +195,8 @@ public class FlagshipEventsPubsubToBigQuery {
   private enum TableName {
     USER_LOGIN_TABLE(0, "user_login"),
     USER_LOGOUT_TABLE(1, "user_logout"),
-    API_CALL_MADE_TABLE(2, "api_call_made");
+    API_CALL_MADE_TABLE(2, "api_call_made"),
+    UNDEFINED(3, null);
 
     private final int index;
     private final String formattedTable;
@@ -209,9 +216,8 @@ public class FlagshipEventsPubsubToBigQuery {
 
     public static TableName getByTable(String table) {
       return Arrays.stream(TableName.values())
-          .filter(it -> it.getFormattedTable().equals(table))
-          .findFirst()
-          .get();
+          .filter(it -> it.getFormattedTable().equals(StringUtils.defaultString(table).toLowerCase()))
+          .findFirst().orElse(UNDEFINED);
     }
   }
 


### PR DESCRIPTION
The derby version here doesn't resolve in Maven unfortunately, so rolling that back until there is an official release that patches that vulnerability.

The original dataflow job had a multi-if statement with no terminal else, so might have been passing a null value to the table write?  Adding logging to trap values that don't match for additional debugging.